### PR TITLE
:recycle: docs, doctests, and accidental heavy refactor

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,40 +22,44 @@ end
 ## Usage
 
 ```elixir
-import RandomWords
+iex(1)> import RandomWords
+RandomWords
 
-word()
-=> hilarious
+iex(2)> :rand.seed(:exsplus, {101, 102, 103})
+# Omitted
 
-words(2)
-=> beefcake fancy
+iex(3)> word()
+"fist"
 
-verb()
-=> run
+iex(4)> words(2)
+["perform", "mix"]
 
-adverb()
-=> greedily
+iex(5)> verb()
+"overlook"
+
+iex(6)> adverb()
+"always"
 
 # Options-based call
-word([part_of_speech: :noun])
-=> fourth
+iex(7)> word([part_of_speech: :noun])
+"people"
 
 # Conjunctive adverbs aren't included in the default list of adverbs.
 # Mix them in with :any_adverb.
-word([part_of_speech: :any_adverb])
-=> that
+iex(8)> word([part_of_speech: :any_adverb])
+"like"
 
 # Numerals, determiners, and adjuncts aren't included in the default list of adjectives
 # Mix them in with :any_adjective
-word([part_of_speech: :any_adjective])
-=> fourth
+iex(9)> word([part_of_speech: :any_adjective])
+"French"
 ```
 
 ## Removed words
 
-I removed damn, shit, and fucking because many people won't want to see them come up at random, and it was easier to remove them than to account for them. If there had been more of them, I would have considered "swears" as a part of speech.
+I removed "damn", "shit", and "fucking" because many people won't want to see them come up at random, and it was easier to remove them than to account for them. If there had been more of them, I would have considered "swears" as a part of speech.
 
-I removed n't because I don't consider it a word at all.
+I removed "n't" because I don't consider it a word at all.
 
 ## Contributing
 

--- a/lib/random_words.ex
+++ b/lib/random_words.ex
@@ -267,7 +267,7 @@ defmodule RandomWords do
     GenServer.call(RandomWords.WordServer, :words)
   end
 
-  @spec parts_of_speech() :: %{required(String.t()) => [String.t()]}
+  @spec parts_of_speech() :: %{required(part_of_speech()) => [String.t()]}
   defp parts_of_speech do
     start_server()
     GenServer.call(RandomWords.WordServer, :parts_of_speech)

--- a/lib/random_words.ex
+++ b/lib/random_words.ex
@@ -1,70 +1,245 @@
 defmodule RandomWords do
   @moduledoc """
   Provide a random word from a list of 5,000 most common American English words.
+
+
+  Word list owned and provided by https://www.wordfrequency.info/. Their terms are that this list cannot be reproduced without crediting them by URL.
   """
   NimbleCSV.define(MyParser, separator: ",", escape: "\"")
 
-  def words(number, _opts \\ []) do
-    Enum.map(1..number, fn _ -> word() end)
-  end
+  @typep word_data :: %{
+           part: String.t(),
+           rank: non_neg_integer(),
+           word: String.t()
+         }
 
-  def word(opts) do
+  @type part_of_speech ::
+          :adjective
+          | :adjunct
+          | :adverb
+          | :conjunctive_adverb
+          | :determiner
+          | :interjection
+          | :noun
+          | :numeral
+          | :preposition
+          | :pronoun
+          | :verb
+
+  @type part_of_speech_options :: :any | :any_adverb | :any_adjective | part_of_speech
+
+  @type opts :: [
+          part_of_speech: part_of_speech_options
+        ]
+
+  @doc """
+  ## Examples
+
+      # Seed random generation for examples
+      iex> :rand.seed(:exsss, {101, 102, 103})
+      iex> RandomWords.words(3)
+      ["green", "scandal", "resistance"]
+  """
+  @spec words(non_neg_integer(), opts()) :: list(String.t())
+  def words(count, opts \\ [part_of_speech: :any]) do
     opts
     |> wordlist()
-    |> get_random()
+    |> Enum.take_random(count)
   end
 
-  def word do
-    data() |> get_random()
-  end
+  @doc """
+  ## Examples
+
+      # Seed random generation for examples
+      iex> :rand.seed(:exsss, {101, 102, 103})
+      iex> RandomWords.word()
+      "straight"
+  """
+  @spec word(opts) :: String.t()
+  def word(opts \\ [part_of_speech: :any]), do: wordlist(opts) |> Enum.random()
 
   @doc """
   Excludes numerals, determiners, and adjuncts. (See any_adjective/0)
-  """
-  def adjective, do: word(part_of_speech: "adjective")
 
-  def adjunct, do: word(part_of_speech: "adjunct")
+  ## Examples
+
+      # Seed random generation for examples
+      iex> :rand.seed(:exsss, {101, 102, 103})
+      iex> RandomWords.adjective()
+      "troubled"
+  """
+  @spec adjective() :: String.t()
+  def adjective, do: word(part_of_speech: :adjective)
+
+  @doc """
+  ## Examples
+
+      # Seed random generation for examples
+      iex> :rand.seed(:exsss, {101, 102, 103})
+      iex> RandomWords.adjunct()
+      "a"
+  """
+  @spec adjunct() :: String.t()
+  def adjunct, do: word(part_of_speech: :adjunct)
 
   @doc """
   Excludes conjunctive adverbs. (See any_adverb/0)
-  """
-  def adverb, do: word(part_of_speech: "adverb")
 
-  def conjunctive_adverb, do: word(part_of_speech: "conjunctive_adverb")
-  def determiner, do: word(part_of_speech: "determiner")
-  def interjection, do: word(part_of_speech: "interjection")
-  def noun, do: word(part_of_speech: "noun")
-  def numeral, do: word(part_of_speech: "numeral")
-  def preposition, do: word(part_of_speech: "preposition")
-  def pronoun, do: word(part_of_speech: "pronoun")
-  def verb, do: word(part_of_speech: "verb")
+  ## Examples
+
+
+      # Seed random generation for examples
+      iex> :rand.seed(:exsss, {101, 102, 103})
+      iex> RandomWords.adverb()
+      "briefly"
+  """
+  @spec adverb() :: String.t()
+  def adverb, do: word(part_of_speech: :adverb)
+
+  @doc """
+  ## Examples
+
+      # Seed random generation for examples
+      iex> :rand.seed(:exsss, {101, 102, 103})
+      iex> RandomWords.conjunctive_adverb()
+      "now"
+  """
+  @spec conjunctive_adverb() :: String.t()
+  def conjunctive_adverb, do: word(part_of_speech: :conjunctive_adverb)
+
+  @doc """
+  ## Examples
+
+      # Seed random generation for examples
+      iex> :rand.seed(:exsss, {101, 102, 103})
+      iex> RandomWords.determiner()
+      "enough"
+  """
+  @spec determiner() :: String.t()
+  def determiner, do: word(part_of_speech: :determiner)
+
+  @doc """
+  ## Examples
+
+      # Seed random generation for examples
+      iex> :rand.seed(:exsss, {101, 102, 103})
+      iex> RandomWords.interjection()
+      "huh"
+  """
+  @spec interjection() :: String.t()
+  def interjection, do: word(part_of_speech: :interjection)
+
+  @doc """
+  ## Examples
+
+      
+      # Seed random generation for examples
+      iex> :rand.seed(:exsss, {101, 102, 103})
+      iex> RandomWords.noun()
+      "fraud"
+  """
+  @spec noun() :: String.t()
+  def noun, do: word(part_of_speech: :noun)
+
+  @doc """
+  ## Examples
+
+      # Seed random generation for examples
+      iex> :rand.seed(:exsss, {101, 102, 103})
+      iex> RandomWords.numeral()
+      "first"
+  """
+  @spec numeral() :: String.t()
+  def numeral, do: word(part_of_speech: :numeral)
+
+  @doc """
+  ## Examples
+
+      # Seed random generation for examples
+      iex> :rand.seed(:exsss, {101, 102, 103})
+      iex> RandomWords.preposition()
+      "under"
+  """
+  @spec preposition() :: String.t()
+  def preposition, do: word(part_of_speech: :preposition)
+
+  @doc """
+  ## Examples
+
+      # Seed random generation for examples
+      iex> :rand.seed(:exsss, {101, 102, 103})
+      iex> RandomWords.pronoun()
+      "anybody"
+  """
+  @spec pronoun() :: String.t()
+  def pronoun, do: word(part_of_speech: :pronoun)
+
+  @doc """
+  ## Examples
+
+      # Seed random generation for examples
+      iex> :rand.seed(:exsss, {101, 102, 103})
+      iex> RandomWords.verb()
+      "depict"
+  """
+  @spec verb() :: String.t()
+  def verb, do: word(part_of_speech: :verb)
 
   @doc """
   Includes numerals, determiners, and adjuncts.
+
+  ## Examples
+
+      # Seed random generation for examples
+      iex> :rand.seed(:exsss, {101, 102, 103})
+      iex> RandomWords.any_adjective()
+      "special"
   """
-  def any_adjective, do: word(part_of_speech: "any_adjective")
+  @spec any_adjective() :: String.t()
+  def any_adjective, do: word(part_of_speech: :any_adjective)
 
   @doc """
   Includes conjunctive adverbs.
+
+  ## Examples
+
+      # Seed random generation for examples
+      iex> :rand.seed(:exsss, {101, 102, 103})
+      iex> RandomWords.any_adverb()
+      "freely"
   """
-  def any_adverb, do: word(part_of_speech: "any_adverb")
+  @spec any_adverb() :: String.t()
+  def any_adverb, do: word(part_of_speech: :any_adverb)
 
-  def wordlist, do: data()
+  @doc """
+  Returns all the words available in any / the specified category.
 
-  def wordlist(part_of_speech: "any_adjective") do
-    speech = parts_of_speech()
+  ## Examples
 
-    speech["adjective"] ++
-      speech["determiner"] ++
-      speech["numeral"] ++ speech["adjunct"]
+      iex> RandomWords.wordlist() |> length()
+      4995
+      iex> RandomWords.wordlist(part_of_speech: :verb) |> length()
+      1001
+  """
+  @spec wordlist(opts) :: list(String.t())
+  def wordlist(opts \\ [part_of_speech: :any])
+
+  def wordlist(part_of_speech: :any) do
+    data() |> Enum.map(&Map.fetch!(&1, :word))
   end
 
-  def wordlist(part_of_speech: "any_adverb") do
-    speech = parts_of_speech()
-    speech["adverb"] ++ speech["conjunctive_adverb"]
+  def wordlist(part_of_speech: :any_adjective) do
+    words_for_parts_of_speech([:adjective, :determiner, :numberal, :adjunct])
   end
 
-  def wordlist(part_of_speech: part), do: parts_of_speech()[part]
+  def wordlist(part_of_speech: :any_adverb) do
+    words_for_parts_of_speech([:adverb, :conjunctive_adverb])
+  end
+
+  def wordlist(part_of_speech: part) do
+    parts_of_speech()
+    |> Map.fetch!(part)
+  end
 
   # Private Functions #
 
@@ -78,20 +253,21 @@ defmodule RandomWords do
     end
   end
 
-  defp get_random(list) do
-    list
-    |> Enum.random()
-    |> case do
-      map when is_map(map) -> map[:word]
-      word -> word
-    end
+  @spec words_for_parts_of_speech(list(part_of_speech())) :: list(String.t())
+  defp words_for_parts_of_speech(parts) do
+    parts_of_speech()
+    |> Map.take(parts)
+    |> Map.values()
+    |> List.flatten()
   end
 
+  @spec data() :: list(word_data())
   defp data do
     start_server()
     GenServer.call(RandomWords.WordServer, :words)
   end
 
+  @spec parts_of_speech() :: %{required(String.t()) => [String.t()]}
   defp parts_of_speech do
     start_server()
     GenServer.call(RandomWords.WordServer, :parts_of_speech)

--- a/lib/word_server.ex
+++ b/lib/word_server.ex
@@ -31,24 +31,15 @@ defmodule RandomWords.WordServer do
     |> File.stream!()
     |> MyParser.parse_stream()
     |> Stream.map(fn [rank, word, part, _frequency, _dispersion, _blank] ->
+      part = part |> String.replace(" ", "_") |> String.to_atom()
       %{rank: String.to_integer(rank), word: word, part: part}
     end)
+    |> Stream.drop(1)
     |> Enum.to_list()
-    |> Enum.drop(1)
   end
 
+  @spec parts_of_speech(any()) :: %{required(String.t()) => [String.t()]}
   defp parts_of_speech(words) do
-    words
-    |> Enum.reduce(%{}, fn datum, acc ->
-      part_name = datum[:part]
-
-      list =
-        case acc[part_name] do
-          nil -> [datum[:word]]
-          list -> [datum[:word] | list]
-        end
-
-      Map.put(acc, part_name, list)
-    end)
+    Enum.group_by(words, &Map.fetch!(&1, :part), &Map.fetch!(&1, :word))
   end
 end

--- a/mix.exs
+++ b/mix.exs
@@ -25,7 +25,8 @@ defmodule RandomWords.MixProject do
   defp deps do
     [
       {:nimble_csv, "~> 0.7"},
-      {:ex_doc, "~> 0.22", only: :dev, runtime: false}
+      {:ex_doc, "~> 0.22", only: :dev, runtime: false},
+      {:dialyxir, "~> 1.0", only: [:dev], runtime: false}
     ]
   end
 

--- a/mix.lock
+++ b/mix.lock
@@ -1,5 +1,7 @@
 %{
+  "dialyxir": {:hex, :dialyxir, "1.0.0", "6a1fa629f7881a9f5aaf3a78f094b2a51a0357c843871b8bc98824e7342d00a5", [:mix], [{:erlex, ">= 0.2.6", [hex: :erlex, repo: "hexpm", optional: false]}], "hexpm", "aeb06588145fac14ca08d8061a142d52753dbc2cf7f0d00fc1013f53f8654654"},
   "earmark": {:hex, :earmark, "1.4.4", "4821b8d05cda507189d51f2caeef370cf1e18ca5d7dfb7d31e9cafe6688106a4", [:mix], [], "hexpm", "1f93aba7340574847c0f609da787f0d79efcab51b044bb6e242cae5aca9d264d"},
+  "erlex": {:hex, :erlex, "0.2.6", "c7987d15e899c7a2f34f5420d2a2ea0d659682c06ac607572df55a43753aa12e", [:mix], [], "hexpm", "2ed2e25711feb44d52b17d2780eabf998452f6efda104877a3881c2f8c0c0c75"},
   "ex_doc": {:hex, :ex_doc, "0.22.1", "9bb6d51508778193a4ea90fa16eac47f8b67934f33f8271d5e1edec2dc0eee4c", [:mix], [{:earmark, "~> 1.4.0", [hex: :earmark, repo: "hexpm", optional: false]}, {:makeup_elixir, "~> 0.14", [hex: :makeup_elixir, repo: "hexpm", optional: false]}], "hexpm", "d957de1b75cb9f78d3ee17820733dc4460114d8b1e11f7ee4fd6546e69b1db60"},
   "makeup": {:hex, :makeup, "1.0.1", "82f332e461dc6c79dbd82fbe2a9c10d48ed07146f0a478286e590c83c52010b5", [:mix], [{:nimble_parsec, "~> 0.5.0", [hex: :nimble_parsec, repo: "hexpm", optional: false]}], "hexpm", "49736fe5b66a08d8575bf5321d716bac5da20c8e6b97714fec2bcd6febcfa1f8"},
   "makeup_elixir": {:hex, :makeup_elixir, "0.14.0", "cf8b7c66ad1cff4c14679698d532f0b5d45a3968ffbcbfd590339cb57742f1ae", [:mix], [{:makeup, "~> 1.0", [hex: :makeup, repo: "hexpm", optional: false]}], "hexpm", "d4b316c7222a85bbaa2fd7c6e90e37e953257ad196dc229505137c5e505e9eff"},

--- a/test/random_words_test.exs
+++ b/test/random_words_test.exs
@@ -27,7 +27,14 @@ defmodule RandomWordsTest do
   end
 
   test "200 words a second" do
-    assert measure(fn -> Enum.each(0..200, fn _ -> RandomWords.word() end) end) < 1
+    time_200_via_word = measure(fn -> Enum.each(0..200, fn _ -> RandomWords.word() end) end)
+    IO.puts("200 words via word() in seconds: #{time_200_via_word}")
+    assert time_200_via_word < 1
+
+    time_200_via_words = measure(fn -> RandomWords.words(200) end)
+    IO.puts("200 words via words() in seconds: #{time_200_via_words}")
+    assert time_200_via_words < 1
+    assert time_200_via_words < time_200_via_word
   end
 
   defp measure(function) do


### PR DESCRIPTION
I'd like to preface this PR with my sincerest thanks for your effort in making this package. It provides exactly the type of resource that I want.

I was having trouble using your package because I couldn't tell what types were going to be returned from `words/1` and the example in the README wasn't working. I initially wanted to make a PR that was all docs and typespecs since someone else may want that information in the future.

However, in implementing those docs (doctests) and typespecs I ran into issues. Failing tests and dialyzer errors plagued me. Eventually, in order to get a working implementation it just so happened that I ended up rewriting a lot of the code.

I also want to note some of the new timings. Using `words/1` for 200 words for me is easily under a tenth (I've even seen around a thousandth) of a second while `word/1` is somewhere from .2 to .5 seconds.

I'm open  to working with you on what changes you want to make to the official package. If you just want docs, that's fine. If you want something else, sounds good. I'll edit the PR accordingly.

Thank you!